### PR TITLE
sync channel feature added

### DIFF
--- a/file_input/lmd_source_multievent.cc
+++ b/file_input/lmd_source_multievent.cc
@@ -127,6 +127,7 @@ lmd_event *lmd_source_multievent::get_event()
   se._header = evnt->_header;
   se._header.h_control = se._header.h_control + 10;
   wrts_header wr(whirr);
+  wr.system_id = wr.system_id +0x1000; //add 1 in front of WRID for the haeckselt data
   if (evnt->sfp_id == 0 && evnt->module_id == 16 && evnt->channel_id == 0){ //SYNC Channel
 	uint32_t energy_val = ((*((evnt->data)+10) & 0x0000ffff)<<16);
 	uint32_t sync_ch_word = energy_val + 0xf1a0;

--- a/file_input/lmd_source_multievent.cc
+++ b/file_input/lmd_source_multievent.cc
@@ -124,14 +124,25 @@ lmd_event *lmd_source_multievent::get_event()
   _file_event._header._info.i_trigger = evnt->trig_type;
   lmd_subevent& se = *(lmd_subevent *)
     _file_event._defrag_event.allocate(sizeof (lmd_subevent));
-  se._header = evnt->_header; //TODO: ctrl+10
-  // TODO: insert sync word for ch 0.16.0
-  se._data   =  (char*)_file_event._defrag_event_many.allocate(WRTS_SIZE+evnt->size); //TODO: sync
+  se._header = evnt->_header;
+  se._header.h_control = se._header.h_control + 10;
   wrts_header wr(whirr);
-  memcpy(se._data, &wr, sizeof(wr));
-  memcpy(se._data+sizeof(wr),
+  if (evnt->sfp_id == 0 && evnt->module_id == 16 && evnt->channel_id == 0){ //SYNC Channel
+	uint32_t sync_ch_word = 0xf1a0;
+	se._data   =  (char*)_file_event._defrag_event_many.allocate(WRTS_SIZE+evnt->size+sizeof(sync_ch_word));
+	memcpy(se._data, &wr, sizeof(wr));
+	memcpy(se._data+sizeof(wr),&sync_ch_word,sizeof(sync_ch_word));
+	memcpy(se._data+sizeof(wr)+sizeof(sync_ch_word),
          evnt->data, evnt->size);
-  se._header._header.l_dlen = (evnt->size+WRTS_SIZE)/2 + 2; // TODO: sync: use value from above/2+2
+	se._header._header.l_dlen = (evnt->size+WRTS_SIZE+sizeof(sync_ch_word))/2 + 2;
+	}
+  else{ // Physics Channels
+	se._data   =  (char*)_file_event._defrag_event_many.allocate(WRTS_SIZE+evnt->size);
+	memcpy(se._data, &wr, sizeof(wr));
+	memcpy(se._data+sizeof(wr),
+         evnt->data, evnt->size);
+	se._header._header.l_dlen = (evnt->size+WRTS_SIZE)/2 + 2;
+	}
   //printf("size=%d\n", se._header._header.l_dlen);
   _TRACE("returning event with evnt->size, l_dlen=%d\n", evnt->size, se._header._header.l_dlen);
   _file_event._subevents=&se;

--- a/file_input/lmd_source_multievent.cc
+++ b/file_input/lmd_source_multievent.cc
@@ -128,8 +128,10 @@ lmd_event *lmd_source_multievent::get_event()
   se._header.h_control = se._header.h_control + 10;
   wrts_header wr(whirr);
   if (evnt->sfp_id == 0 && evnt->module_id == 16 && evnt->channel_id == 0){ //SYNC Channel
-	uint32_t sync_ch_word = 0xf1a0;
-	se._data   =  (char*)_file_event._defrag_event_many.allocate(WRTS_SIZE+evnt->size+sizeof(sync_ch_word));
+	uint32_t energy_val = ((*((evnt->data)+10) & 0x0000ffff)<<16);
+	uint32_t sync_ch_word = energy_val + 0xf1a0;
+	se._data = (char*)_file_event._defrag_event_many.allocate(WRTS_SIZE+evnt->size+sizeof(sync_ch_word));
+
 	memcpy(se._data, &wr, sizeof(wr));
 	memcpy(se._data+sizeof(wr),&sync_ch_word,sizeof(sync_ch_word));
 	memcpy(se._data+sizeof(wr)+sizeof(sync_ch_word),


### PR DESCRIPTION
With the "sync channel" - feature the Haecksler can differentiate between physics events and sync trigger events (from main DAQ or whatever). The input from the sync trigger goes to SFP 0, FBX/Module 10 , Channel 0.
Output of  haecksler from sync trigger signals:
Event           723 Type/Subtype   10    1 Size      104 Trigger  1
 SubEv ProcID    13 Type/Subtype  10010000 Size       84 Ctrl 101 Subcrate   2
 00000b00 03e114eb 04e12c4f 05e1d4e9 06e1166d 0000**f1a0** 060c0134 00000034
 115a0034 001dcc71 d50f0d4d 000000c7 0057005e 005b0056 00002000 00000000
 00000161 01300128 beef0000 05778532 ffe60005

When the haecksler detects trigger signal, it adds the special word **f1a0** after the wr-ts block.

Furthermore now the hacksler changed the **Ctrl number** to **Ctrl number + 10**. This makes it easy to differentiate between haeckelt and not haeckselt events.
